### PR TITLE
Provide php@major@ version of all packages.

### DIFF
--- a/debian/control.in
+++ b/debian/control.in
@@ -93,6 +93,7 @@ Depends: libmagic1,
          ${misc:Depends},
          ${shlibs:Depends}
 Provides: libapache2-mod-php,
+          libapache2-mod-php@PHP_MAJOR@,
           ${php:Provides}
 Suggests: php-pear
 Description: server-side, HTML-embedded scripting language (Apache 2 module)
@@ -116,6 +117,7 @@ Depends: libmagic1,
          ${misc:Depends},
          ${shlibs:Depends}
 Provides: libphp-embed,
+          libphp@PHP_MAJOR@-embed,
           ${php:Provides}
 Suggests: php-pear
 Description: HTML-embedded scripting language (Embedded SAPI library)
@@ -137,7 +139,8 @@ Architecture: all
 Depends: php@PHP_VERSION@-fpm | libapache2-mod-php@PHP_VERSION@ | php@PHP_VERSION@-cgi,
          php@PHP_VERSION@-common,
          ${misc:Depends}
-Provides: php
+Provides: php,
+          php@PHP_MAJOR@
 Description: server-side, HTML-embedded scripting language (metapackage)
  This package is a metapackage that, when installed, guarantees that you
  have at least one of the four server-side versions of the PHP interpreter
@@ -161,6 +164,7 @@ Depends: libmagic1,
          ${misc:Depends},
          ${shlibs:Depends}
 Provides: php-cgi,
+          php@PHP_MAJOR@-cgi,
           ${php:Provides}
 Suggests: php-pear
 Description: server-side, HTML-embedded scripting language (CGI binary)
@@ -188,6 +192,7 @@ Depends: libedit2 (>= 2.11-20080614-4),
          ${misc:Depends},
          ${shlibs:Depends}
 Provides: php-cli,
+          php@PHP_MAJOR@-cli,
           ${php:Provides}
 Suggests: php-pear
 Description: command-line interpreter for the PHP scripting language
@@ -236,6 +241,7 @@ Depends: libmagic1,
          ${misc:Depends},
          ${shlibs:Depends}
 Provides: php-fpm,
+          php@PHP_MAJOR@-fpm,
           ${php:Provides}
 Suggests: php-pear
 Pre-Depends: ${misc:Pre-Depends}
@@ -260,6 +266,7 @@ Depends: libmagic1,
          ${misc:Depends},
          ${shlibs:Depends}
 Provides: php-phpdbg,
+          php@PHP_MAJOR@-phpdbg,
           ${php:Provides}
 Recommends: php-readline
 Description: server-side, HTML-embedded scripting language (PHPDBG binary)

--- a/debian/php-module.control.in
+++ b/debian/php-module.control.in
@@ -12,7 +12,8 @@ Built-Using: ${php:Built-Using}
 Replaces: ${php-@ext@:Replaces}
 Breaks: ${php-@ext@:Breaks}
 Conflicts: ${php-@ext@:Conflicts}
-Provides: ${php-@ext@:Provides}
+Provides: php@php_major@-@ext@,
+          ${php-@ext@:Provides}
 Description: @description@ module for PHP
  This package provides the @description@ module(s) for PHP.
  .

--- a/debian/rules
+++ b/debian/rules
@@ -569,12 +569,15 @@ override_dh_gencontrol-arch:
 	dh_gencontrol -a
 
 debian/control: debian/control.in debian/rules debian/changelog debian/source.lintian-overrides debian/rules.d/* debian/php-module.control.in
-	$(SED) -e "s/@PHP_VERSION@/$(PHP_NAME_VERSION)/g" -e "s/@BUILT_USING@/$(BUILT_USING)/g" >$@ <$<
+	$(SED) -e "s/@PHP_MAJOR@/$(PHP_MAJOR_VERSION)/g" \
+	       -e "s/@PHP_VERSION@/$(PHP_NAME_VERSION)/g" \
+		   -e "s/@BUILT_USING@/$(BUILT_USING)/g" >$@ <$<
 	for ext in $(ext_PACKAGES); do \
 	  package=php$(PHP_NAME_VERSION)-$${ext}; \
 	  description=$$(eval echo \$${$${ext}_DESCRIPTION}); \
 	  echo >>$@; \
-	  $(SED) -e "s|@ext@|$${ext}|" -e "s|@package@|$${package}|" -e "s|@description@|$${description}|" >>$@ <debian/php-module.control.in; \
+	  $(SED) -e "s|@ext@|$${ext}|" -e "s|@package@|$${package}|" \
+	         -e "s|@php_major@|$(PHP_MAJOR_VERSION)|" -e "s|@description@|$${description}|" >>$@ <debian/php-module.control.in; \
 	done
 	mkdir -p debian/tests
 	for f in debian/tests.in/*; do \


### PR DESCRIPTION
This adds a provide field on all packages with current major version
instead of major.minor version (e.g php5.6 provides php5).

Many ubuntu packages depend on php5 and not on php or php5.6...
For example dokuwiki (http://packages.ubuntu.com/trusty/dokuwiki) depends on php5 and suggests php5-gd.
